### PR TITLE
fix(container): update home-assistant docker tag to v2023.1.5

### DIFF
--- a/cluster/apps/home/assistant/helm-release.yaml
+++ b/cluster/apps/home/assistant/helm-release.yaml
@@ -31,7 +31,7 @@ spec:
       fullnameOverride: assistant
     image:
       repository: ghcr.io/home-assistant/home-assistant
-      tag: 2023.1.4
+      tag: 2023.1.5
 
 
 


### PR DESCRIPTION
| datasource | package                               | from     | to       |
| ---------- | ------------------------------------- | -------- | -------- |
| docker     | ghcr.io/home-assistant/home-assistant | 2023.1.4 | 2023.1.5 |