### PR TITLE
Revert "feat(helm): update chart external-dns ( 1.15.2 → 1.16.0 )"

### DIFF
--- a/k8s/nebula/apps/networking/external-dns/external/helm-release.yaml
+++ b/k8s/nebula/apps/networking/external-dns/external/helm-release.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       # renovate: registryUrl=https://kubernetes-sigs.github.io/external-dns
       chart: external-dns
-      version: 1.16.0
+      version: 1.15.2
       sourceRef:
         kind: HelmRepository
         name: external-dns-charts

--- a/k8s/nebula/apps/networking/external-dns/internal-kapsi/helm-release.yaml
+++ b/k8s/nebula/apps/networking/external-dns/internal-kapsi/helm-release.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       # renovate: registryUrl=https://kubernetes-sigs.github.io/external-dns
       chart: external-dns
-      version: 1.16.0
+      version: 1.15.2
       sourceRef:
         kind: HelmRepository
         name: external-dns-charts

--- a/k8s/nebula/apps/networking/external-dns/internal/helm-release.yaml
+++ b/k8s/nebula/apps/networking/external-dns/internal/helm-release.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       # renovate: registryUrl=https://kubernetes-sigs.github.io/external-dns
       chart: external-dns
-      version: 1.16.0
+      version: 1.15.2
       sourceRef:
         kind: HelmRepository
         name: external-dns-charts


### PR DESCRIPTION
Reverts samip5/k8s-cluster#2163

```
external-dns-external   214d   False   Helm upgrade failed for release networking/external-dns-external with chart external-dns@1.16.0: values don't meet the specifications of the schema(s) in the following chart(s):...
external-dns-internal   251d   False   Helm upgrade failed for release networking/external-dns-internal with chart external-dns@1.16.0: values don't meet the specifications of the schema(s) in the following chart(s):...
```