### PR TITLE
Revert "feat(helm): update chart external-dns ( 1.15.2 → 1.16.0 )"

### DIFF
--- a/k8s/media/apps/networking/external-dns/internal/helm-release.yaml
+++ b/k8s/media/apps/networking/external-dns/internal/helm-release.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       # renovate: registryUrl=https://kubernetes-sigs.github.io/external-dns
       chart: external-dns
-      version: 1.16.0
+      version: 1.15.2
       sourceRef:
         kind: HelmRepository
         name: external-dns-charts


### PR DESCRIPTION
Reverts samip5/k8s-cluster#2162